### PR TITLE
add missing images to registry, allow builder to pull from registry and nexus is a dc not deployment

### DIFF
--- a/ansible/resources/process-service/openjdk-imagestream.yml
+++ b/ansible/resources/process-service/openjdk-imagestream.yml
@@ -1,0 +1,14 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ openjdk_imagestream_name }}
+  namespace: {{ application_image_namespace }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:{{ openjdk_imagestream_tag }}
+    name: "1.6"

--- a/ansible/resources/sso/sso-imagestream.yml
+++ b/ansible/resources/sso/sso-imagestream.yml
@@ -1,0 +1,14 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ theme_build_imagestream }}
+  namespace: {{ theme_build_imagestream_namespace }}
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/redhat-sso-7/sso73-openshift:{{ theme_build_imagestream_tag }}
+    name: "1.0"

--- a/ansible/roles/openshift_nexus/tasks/uninstall.yml
+++ b/ansible/roles/openshift_nexus/tasks/uninstall.yml
@@ -6,7 +6,7 @@
     state: absent
     name: "{{ nexus_service_name }}"
     namespace: "{{ namespace }}"
-    kind: deployment
+    kind: deploymentconfig
 
 - name: delete nexus route
   oc_obj:

--- a/ansible/roles/openshift_process_service/defaults/main.yml
+++ b/ansible/roles/openshift_process_service/defaults/main.yml
@@ -47,6 +47,10 @@ imagestream_name: "{{ application_name }}"
 
 application_template: process-service.yml
 
+openjdk_template: openjdk-imagestream.yml
+openjdk_imagestream_name: openjdk18-openshift
+openjdk_imagestream_tag: 1.6
+
 application_image: openjdk18-openshift:1.6
 application_image_namespace: openshift
 

--- a/ansible/roles/openshift_process_service/tasks/main.yml
+++ b/ansible/roles/openshift_process_service/tasks/main.yml
@@ -87,6 +87,21 @@
     files:
       - "{{ work_dir }}/{{ buildconfig_template }}"
 
+- name: copy openjdk imagestream template to work directory
+  template:
+    src: "{{ resources_dir }}/{{ openjdk_template }}"
+    dest: "{{ work_dir }}/{{ openjdk_template }}"
+
+- name: create opensjdk imagestream
+  oc_obj:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: "{{ openjdk_imagestream_name }}"
+    namespace: "{{ application_image_namespace }}"
+    kind: is
+    files:
+      - "{{ work_dir }}/{{ openjdk_template }}"
+
 - name: copy imagestream template
   template:
     src: "{{ resources_dir }}/{{ imagestream_template }}"

--- a/ansible/roles/openshift_sso/defaults/main.yml
+++ b/ansible/roles/openshift_sso/defaults/main.yml
@@ -13,6 +13,8 @@ theme_build_imagestream: redhat-sso73-openshift
 theme_build_imagestream_tag: 1.0
 theme_build_imagestream_namespace: openshift
 
+sso_image_template: sso-imagestream.yml
+
 sso_application_name: sso
 sso_template: "{{ resources_dir}}/sso73-x509-postgresql-persistent.yml"
 

--- a/ansible/roles/openshift_sso/tasks/main.yml
+++ b/ansible/roles/openshift_sso/tasks/main.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: make sure we can pull from registry
+  shell: oc secrets link builder imagestreamsecret -n openshift
+
+- name: copy SSO imagestream template to work directory
+  template:
+    src: "{{ resources_dir }}/{{ sso_image_template }}"
+    dest: "{{ work_dir }}/{{ sso_image_template }}"
+
+- name: create SSO imagestream
+  oc_obj:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: "{{ theme_build_imagestream }}"
+    namespace: "{{ theme_build_imagestream_namespace }}"
+    kind: is
+    files:
+      - "{{ work_dir }}/{{ sso_image_template }}"
+
 - name: copy theme build template to work directory
   template:
     src: "{{ theme_build_template }}"


### PR DESCRIPTION
* Add missing images
* Ensure we can pull images from terms-based-registry
* Uninstall would stall because the dc for nexus existed and the pvc would never delete

Addresses #10