### PR TITLE
Add standalone monitoring

### DIFF
--- a/ansible/playbooks/group_vars/monitoring.yml
+++ b/ansible/playbooks/group_vars/monitoring.yml
@@ -1,3 +1,3 @@
 ---
 
-namespace_monitoring: "{{ project_name }}"
+namespace_monitoring: emergency-response-monitoring

--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -11,7 +11,8 @@
 
   tasks:
     - set_fact:
-        namespace: "{{ namespace_services }}"
+        namespace: "{{ namespace_monitoring }}"
+        monitor_namespace: "{{ namespace_services }}"
         resources_dir: "{{ resources_base_dir }}/monitoring"
         work_dir_name: monitoring
     - include_role:

--- a/ansible/resources/monitoring/alert_manager_cluster_role.yml
+++ b/ansible/resources/monitoring/alert_manager_cluster_role.yml
@@ -1,0 +1,19 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: alertmanager-application-monitoring
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  attributeRestrictions: null
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  attributeRestrictions: null
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/ansible/resources/monitoring/alert_manager_cluster_role_binding.yml
+++ b/ansible/resources/monitoring/alert_manager_cluster_role_binding.yml
@@ -1,0 +1,13 @@
+apiVersion: authorization.openshift.io/v1
+groupNames: null
+kind: ClusterRoleBinding
+metadata:
+  name: emergency-response-alertmanager-application-monitoring
+roleRef:
+  name: alertmanager-application-monitoring
+subjects:
+- kind: ServiceAccount
+  name: alertmanager
+  namespace: "{{ application_monitoring_namespace }}"
+userNames:
+- system:serviceaccount:{{ application_monitoring_namespace }}:alertmanager

--- a/ansible/resources/monitoring/application-actuator-servicemonitor.yml
+++ b/ansible/resources/monitoring/application-actuator-servicemonitor.yml
@@ -3,9 +3,8 @@ kind: ServiceMonitor
 metadata:
   labels:
     k8s-app: prometheus
-    monitoring-key: middleware
+    monitoring-key: "{{ application_monitoring_label_value }}"
   name: emergency-services-actuator-monitor-services
-  namespace: "{{ project_name }}"
 spec:
   endpoints:
     - interval: 5s

--- a/ansible/resources/monitoring/application-grafanadashboard.yml
+++ b/ansible/resources/monitoring/application-grafanadashboard.yml
@@ -2,7 +2,6 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: emergency-response-dashboard
-  namespace: "{{ namespace }}"
 spec:
   json: |
     {

--- a/ansible/resources/monitoring/application-servicemonitor.yml
+++ b/ansible/resources/monitoring/application-servicemonitor.yml
@@ -4,9 +4,8 @@ metadata:
   generation: 1
   labels:
     k8s-app: prometheus
-    monitoring-key: middleware
+    monitoring-key: "{{ application_monitoring_label_value }}"
   name: metrics-monitor-services
-  namespace: {{ project_name }}
 spec:
   endpoints:
     - interval: 5s

--- a/ansible/resources/monitoring/application_monitoring_cr.yml
+++ b/ansible/resources/monitoring/application_monitoring_cr.yml
@@ -1,0 +1,6 @@
+apiVersion: applicationmonitoring.integreatly.org/v1alpha1
+kind: ApplicationMonitoring
+metadata:
+  name: application-monitoring
+spec:
+  labelSelector: {{ application_monitoring_label_value }}

--- a/ansible/resources/monitoring/grafana_cluster_role.yml
+++ b/ansible/resources/monitoring/grafana_cluster_role.yml
@@ -1,0 +1,22 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-operator-cluster-role
+rules:
+  - apiGroups:
+      - ""
+    attributeRestrictions: null
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - integreatly.org
+    attributeRestrictions: null
+    resources:
+      - grafanadashboards
+      - grafanas
+    verbs:
+      - '*'

--- a/ansible/resources/monitoring/grafana_cluster_role_binding.yml
+++ b/ansible/resources/monitoring/grafana_cluster_role_binding.yml
@@ -1,0 +1,12 @@
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: emergency-response-grafana-operator
+roleRef:
+  name: grafana-operator-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: grafana-serviceaccount
+    namespace: "{{ application_monitoring_namespace }}"
+userNames:
+  - system:serviceaccount:{{ application_monitoring_namespace }}:grafana-serviceaccount

--- a/ansible/resources/monitoring/kafka-servicemonitor.yml
+++ b/ansible/resources/monitoring/kafka-servicemonitor.yml
@@ -3,9 +3,8 @@ kind: ServiceMonitor
 metadata:
   labels:
     k8s-app: prometheus
-    monitoring-key: middleware
+    monitoring-key: "{{ application_monitoring_label_value }}"
   name: metrics-monitor-kafka
-  namespace: {{ project_name }}
 spec:
   endpoints:
     - interval: 5s

--- a/ansible/resources/monitoring/prometheus_cluster_role.yml
+++ b/ansible/resources/monitoring/prometheus_cluster_role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-application-monitoring
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/ansible/resources/monitoring/prometheus_cluster_role_binding.yml
+++ b/ansible/resources/monitoring/prometheus_cluster_role_binding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: emergency-response-prometheus-application-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-application-monitoring
+subjects:
+- kind: ServiceAccount
+  name: prometheus-application-monitoring
+  namespace: "{{ application_monitoring_namespace }}"
+userNames:
+- system:serviceaccount:{{ application_monitoring_namespace }}:prometheus-application-monitoring

--- a/ansible/resources/monitoring/prometheus_operator_cluster_role.yml
+++ b/ansible/resources/monitoring/prometheus_operator_cluster_role.yml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-application-monitoring-operator
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - prometheuses/finalizers
+  - alertmanagers/finalizers
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - services/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/ansible/resources/monitoring/prometheus_operator_cluster_role_binding.yml
+++ b/ansible/resources/monitoring/prometheus_operator_cluster_role_binding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: emergency-response-prometheus-application-monitoring-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-application-monitoring-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: "{{ application_monitoring_namespace }}"
+userNames:
+- system:serviceaccount:{{ application_monitoring_namespace }}:prometheus-operator

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+application_monitoring_namespace: emergency-response-monitoring
+application_monitoring_release: '0.0.5-monitoring-key'
+application_monitoring_resources_repo: https://raw.githubusercontent.com/aidenkeating/application-monitoring-operator/{{ application_monitoring_release }}/deploy
+application_monitoring_label_value: emergency-response
+
+monitoring_sa: "{{ application_monitoring_resources_repo }}/operator_roles/service_account.yaml"
+monitoring_role: "{{ application_monitoring_resources_repo }}/operator_roles/role.yaml"
+monitoring_role_binding: "{{ application_monitoring_resources_repo }}/operator_roles/role_binding.yaml"
+monitoring_operator: "{{ application_monitoring_resources_repo }}/operator.yaml"
+
+monitoring_cr: application_monitoring_cr.yml
+monitoring_prom_crb: prometheus_cluster_role_binding.yml
+monitoring_am_crb: alert_manager_cluster_role_binding.yml
+monitoring_graf_crb: grafana_cluster_role_binding.yml
+monitoring_prom_operator_crb: prometheus_operator_cluster_role_binding.yml

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -1,7 +1,113 @@
 ---
 
+- template:
+    src: "{{ resources_dir }}/{{ monitoring_prom_crb }}"
+    dest: "{{ work_dir }}/{{ monitoring_prom_crb }}"
+
+- oc_obj:
+    state: present
+    kind: ClusterRoleBinding
+    name: emergency-response-prometheus-application-monitoring
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ work_dir }}/{{ monitoring_prom_crb }}"
+
+- template:
+    src: "{{ resources_dir }}/{{ monitoring_am_crb }}"
+    dest: "{{ work_dir }}/{{ monitoring_am_crb }}"
+
+- oc_obj:
+    state: present
+    kind: ClusterRoleBinding
+    name: emergency-response-alertmanager-application-monitoring
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ work_dir }}/{{ monitoring_am_crb }}"
+
+- template:
+    src: "{{ resources_dir }}/{{ monitoring_graf_crb }}"
+    dest: "{{ work_dir }}/{{ monitoring_graf_crb }}"
+
+- oc_obj:
+    state: present
+    kind: ClusterRoleBinding
+    name: emergency-response-grafana-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ work_dir }}/{{ monitoring_graf_crb }}"
+
+- template:
+    src: "{{ resources_dir }}/{{ monitoring_prom_operator_crb }}"
+    dest: "{{ work_dir }}/{{ monitoring_prom_operator_crb }}"
+
+- oc_obj:
+    state: present
+    kind: ClusterRoleBinding
+    name: emergency-response-prometheus-application-monitoring-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ work_dir }}/{{ monitoring_prom_operator_crb }}"
+
+- oc_obj:
+    state: present
+    kind: ServiceAccount
+    name: application-monitoring-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ monitoring_sa }}"
+
+- oc_obj:
+    state: present
+    kind: Role
+    name: application-monitoring-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ monitoring_role }}"
+
+- oc_obj:
+    state: present
+    kind: RoleBinding
+    name: application-monitoring-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ monitoring_role_binding }}"
+
+- debug: msg="Creating operator {{ monitoring_operator }}"
+
+- oc_obj:
+    state: present
+    kind: Deployment
+    name: application-monitoring-operator
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ monitoring_operator }}"
+
+- template:
+    src: "{{ resources_dir }}/{{ monitoring_cr }}"
+    dest: "{{ work_dir }}/{{ monitoring_cr }}"
+
+- oc_obj:
+    state: present
+    kind: ApplicationMonitoring
+    name: application-monitoring
+    oc_binary: "{{ openshift_cli }}"
+    namespace: "{{ namespace }}"
+    files:
+      - "{{ work_dir }}/{{ monitoring_cr }}"
+
 - name: Update namespace with monitoring label
-  shell: oc label namespace {{ namespace }} monitoring-key=middleware --overwrite
+  shell: oc label namespace {{ monitor_namespace }} monitoring-key={{ application_monitoring_label_value }} --overwrite
+
+- name: Update monitoring namespace with monitoring label
+  shell: oc label namespace {{ namespace }} monitoring-key={{ application_monitoring_label_value }} --overwrite
 
 - name: Copy Kafka ServiceMonitor template
   template:
@@ -27,7 +133,7 @@
     state: present
     oc_binary: "{{ openshift_cli }}"
     name: metrics-monitor-kafka
-    namespace: "{{ namespace }}"
+    namespace: "{{ monitor_namespace }}"
     kind: ServiceMonitor
     files:
       - "{{ work_dir }}/kafka-servicemonitor.yml"
@@ -36,17 +142,16 @@
     state: present
     oc_binary: "{{ openshift_cli }}"
     name: metrics-monitor-services
-    namespace: "{{ namespace }}"
+    namespace: "{{ monitor_namespace }}"
     kind: ServiceMonitor
     files:
       - "{{ work_dir }}/application-servicemonitor.yml"
-
 
 - oc_obj:
     state: present
     oc_binary: "{{ openshift_cli }}"
     name: emergency-services-actuator-monitor-services
-    namespace: "{{ namespace }}"
+    namespace: "{{ monitor_namespace }}"
     kind: ServiceMonitor
     files:
       - "{{ work_dir }}/application-actuator-servicemonitor.yml"

--- a/ansible/roles/openshift_install/tasks/main.yml
+++ b/ansible/roles/openshift_install/tasks/main.yml
@@ -302,5 +302,6 @@
     name: monitoring
   vars:
     namespace: "{{ namespace_monitoring }}"
+    monitor_namespace: "{{ namespace_services }}"
     resources_dir: "{{ resources_base_dir }}/monitoring"
     work_dir_name: monitoring


### PR DESCRIPTION
Currently, the emergency response demo uses the Integreatly
monitoring instance and creates its GrafanaDashboard and Service-
Monitor custom resources against that.

Instead we should use a standalone monitoring stack using it's own
label selectors etc. as this is not the intended way the Integreatly
monitoring stack should be used.