### PR TITLE
Role for installation of Kafka Lag Exporter

### DIFF
--- a/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
+++ b/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
@@ -23,7 +23,7 @@ spec:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 2,
+      "id": 3,
       "links": [],
       "panels": [
         {
@@ -244,7 +244,7 @@ spec:
           "description": "Container Memory usage as reported by OpenShift",
           "fill": 1,
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 8,
             "x": 16,
             "y": 0
@@ -1066,14 +1066,474 @@ spec:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
-          "description": "Throughput of messages through the Vertx Event Bus",
+          "description": "Number of Kafka messages consumed.\nCalculated as per-second average rate over the last minute.",
           "fill": 1,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 42
+          },
+          "id": 18,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kafka:messages_consumed:total:rate1m{job=\"{{ project_admin }}-incident-priority-service\", pod=~\"{{ project_admin }}-incident-priority-service-.*\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{topic}} {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Messages Consumed ",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "per second",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 28,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Time lag",
+              "color": "#FA6400",
+              "yaxis": 1
+            },
+            {
+              "alias": "Offset lag",
+              "color": "#FADE2A",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kafka_consumergroup_group_max_lag_seconds{group=\"incident-priority\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "Time lag",
+              "refId": "A"
+            },
+            {
+              "expr": "kafka_consumergroup_group_max_lag{group=\"incident-priority\"}",
+              "format": "time_series",
+              "instant": false,
+              "intervalFactor": 1,
+              "legendFormat": "Offset lag",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Consumer Group Lag In Time Over Offset Lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": "estimated time lag",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "lag in offsets",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "HTTP request latency for the '/priority/:incident' path measured over the last minute.",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 22,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(vertx:http_responsetime:sum:rate1m/vertx:http_responsetime:count:rate1m{job=\"{{ project_admin }}-incident-priority-service\", path=\"/priority/:incidentId\"})*1000",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "code {{code}} - {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "HTTP Requests Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "milliseconds",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "HTTP request throughput for the '/priority/:incident' path measured over the last minute.",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 50
+          },
+          "id": 24,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "vertx:http_responsetime:count:rate1m{job=\"{{ project_admin }}-incident-priority-service\", path=\"/priority/:incidentId\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "code {{code}} - {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "HTTP Request Throughput",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "per second",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "description": "Number of Incidents in KIE Session.\nCalculated as the average and the maximum over the last minute.",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 58
+          },
+          "id": 20,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum_over_time(kiesession_incidents[1m])/count_over_time(kiesession_incidents[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Avg",
+              "refId": "A"
+            },
+            {
+              "expr": "max_over_time(kiesession_incidents[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Max",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Incidents in KIE Session",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Throughput of messages through the Vertx Event Bus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 58
           },
           "id": 16,
           "legend": {
@@ -1100,7 +1560,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(vertx_eventbus_delivered_total[5m])",
+              "expr": "rate(vertx_eventbus_delivered_total[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1151,7 +1611,7 @@ spec:
           }
         }
       ],
-      "refresh": false,
+      "refresh": "10s",
       "schemaVersion": 18,
       "style": "dark",
       "tags": [],
@@ -1189,6 +1649,6 @@ spec:
       },
       "timezone": "",
       "title": "Incident Priority Service",
-      "version": 1
+      "version": 15
     }
   name: incident-priority-service-dashboard.json

--- a/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
+++ b/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
@@ -730,7 +730,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg((rate(rules_assignment_timer_seconds_sum[1m])/rate(rules_assignment_timer_seconds_count[1m]))*1000)",
+              "expr": "avg((rules:assignment:sum:rate1m/rules:assignment:count:rate1m)*1000)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -738,7 +738,7 @@ spec:
               "refId": "A"
             },
             {
-              "expr": "max((rate(rules_assignment_timer_seconds_sum[1m])/rate(rules_assignment_timer_seconds_count[1m]))*1000)",
+              "expr": "max((rules:assignment:sum:rate1m/rules:assignment:count:rate1m)*1000)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max",
@@ -826,7 +826,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(rules_assignment_timer_seconds_count[1m]))",
+              "expr": "avg(rules:assignment:count:rate1m)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -915,7 +915,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg((rate(rules_query_timer_seconds_sum[1m])/rate(rules_query_timer_seconds_count[1m]))*1000)",
+              "expr": "avg((rules:query:sum:rate1m/rules:query:count:rate1m)*1000)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -923,7 +923,7 @@ spec:
               "refId": "A"
             },
             {
-              "expr": "max((rate(rules_query_timer_seconds_sum[1m])/rate(rules_query_timer_seconds_count[1m]))*1000)",
+              "expr": "max((rules:query:sum:rate1m/rules:query:count:rate1m)*1000)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Max",
@@ -1011,7 +1011,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(rules_query_timer_seconds_count[1m]))",
+              "expr": "avg(rules:query:count:rate1m)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,

--- a/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
+++ b/ansible/resources/erd-monitoring/incident-priority-service-dashboard.yml
@@ -1,0 +1,1194 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: incident-priority-service-dashboard
+  labels:
+    monitoring-key: "{{ application_monitoring_label_value }}"
+spec:
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 2,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Heap Memory Usage as reported by JVM",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "interval": "",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(jvm_memory_used_bytes{area=\"heap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Used heap {{pod}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(jvm_memory_max_bytes{area=\"heap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Max heap {{pod}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(jvm_memory_committed_bytes{area=\"heap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Committed heap {{pod}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage Heap",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Non Heap Memory Usage as reported by JVM",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 0
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(jvm_memory_used_bytes{area=\"nonheap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Used non heap {{pod}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(jvm_memory_max_bytes{area=\"nonheap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Max non heap {{pod}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(jvm_memory_committed_bytes{area=\"nonheap\",job=\"{{ project_admin }}-incident-priority-service\"}) by (pod)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Committed non heap {{pod}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory Usage Non Heap",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "OpenShift Monitoring",
+          "description": "Container Memory usage as reported by OpenShift",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 0
+          },
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(container_memory_working_set_bytes{pod=~'{{ project_admin }}-incident-priority-service-.*',namespace='{{ namespace_services }}',container='',}) BY (pod, namespace)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Memory OpenShift",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "CPU usage as reported by the JVM",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "system_cpu_usage{job=\"{{ project_admin }}-incident-priority-service\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "System {{pod}}",
+              "refId": "A"
+            },
+            {
+              "expr": "process_cpu_usage{job=\"{{ project_admin }}-incident-priority-service\"}",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Process {{pod}}",
+              "refId": "B"
+            },
+            {
+              "expr": "avg_over_time(process_cpu_usage{job=\"{{ project_admin }}-incident-priority-service\"}[15m])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Process Avg 15m {{pod}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage JVM",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "OpenShift Monitoring",
+          "description": "Total CPU usage as reported by OpenShift in millicore",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "pod:container_cpu_usage:sum{namespace=\"{{ namespace_services }}\", pod=~\"{{ project_admin }}-incident-priority-service-.*\"}*1000",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU total {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "CPU Usage OpenShift",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "millicore",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(jvm_gc_pause_seconds_count{job=\"{{ project_admin }}-incident-priority-service\"}[1m])*60",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "GC Rate {{action}} {{cause}} {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GC Rate per Minute",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "Rate per minute",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(rate(jvm_gc_pause_seconds_sum{job=\"{{ project_admin }}-incident-priority-service\"}[1m])/rate(jvm_gc_pause_seconds_count{job=\"{{ project_admin }}-incident-priority-service\"}[1m]))*1000",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{action}} {{cause}} {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "GC Duration",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "milliseconds",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Latency of priority assignment rules executions",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 12,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg((rate(rules_assignment_timer_seconds_sum[1m])/rate(rules_assignment_timer_seconds_count[1m]))*1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Average",
+              "refId": "A"
+            },
+            {
+              "expr": "max((rate(rules_assignment_timer_seconds_sum[1m])/rate(rules_assignment_timer_seconds_count[1m]))*1000)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Max",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rules Execution Latency Priority Assignment",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "milliseconds",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Average number of priority assignment rules executions per second",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 13,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(rate(rules_assignment_timer_seconds_count[1m]))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Average",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rules Execution Throughput Priority Assignment",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "per second",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Latency of priority query rules executions",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg((rate(rules_query_timer_seconds_sum[1m])/rate(rules_query_timer_seconds_count[1m]))*1000)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Average",
+              "refId": "A"
+            },
+            {
+              "expr": "max((rate(rules_query_timer_seconds_sum[1m])/rate(rules_query_timer_seconds_count[1m]))*1000)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "Max",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rules Execution Latency Priority Query",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "milliseconds",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Average number of priority query rules executions per second",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 15,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "avg(rate(rules_query_timer_seconds_count[1m]))",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Average",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rules Execution Throughput Priority Query",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "per second",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "Throughput of messages through the Vertx Event Bus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {},
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(vertx_eventbus_delivered_total[5m])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Vertx EventBus Throughput",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "per second",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 18,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "",
+      "title": "Incident Priority Service",
+      "version": 1
+    }
+  name: incident-priority-service-dashboard.json

--- a/ansible/resources/erd-monitoring/incident-priority-service-prometheus-rules.yml
+++ b/ansible/resources/erd-monitoring/incident-priority-service-prometheus-rules.yml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: incident-priority-service-prometheus-rules
+spec:
+  groups:
+    - name: incident-priority-service.rules
+      rules:
+        - record: rules:assignment:sum:rate1m
+          expr: rate(rules_assignment_timer_seconds_sum[1m])
+        - record: rules:assignment:count:rate1m
+          expr: rate(rules_assignment_timer_seconds_count[1m])
+        - record: rules:query:sum:rate1m
+          expr: rate(rules_query_timer_seconds_sum[1m])
+        - record: rules:query:count:rate1m
+          expr: rate(rules_query_timer_seconds_count[1m])

--- a/ansible/resources/erd-monitoring/incident-priority-service-prometheus-rules.yml
+++ b/ansible/resources/erd-monitoring/incident-priority-service-prometheus-rules.yml
@@ -14,3 +14,9 @@ spec:
           expr: rate(rules_query_timer_seconds_sum[1m])
         - record: rules:query:count:rate1m
           expr: rate(rules_query_timer_seconds_count[1m])
+        - record: kafka:messages_consumed:total:rate1m
+          expr: rate(kafka_message_consumed_total[1m])          
+        - record: vertx:http_responsetime:count:rate1m
+          expr: rate(vertx_http_server_responseTime_seconds_count[1m])
+        - record: vertx:http_responsetime:sum:rate1m
+          expr: rate(vertx_http_server_responseTime_seconds_sum[1m])

--- a/ansible/resources/erd-monitoring/openshift-monitoring-grafanadatasource.yml
+++ b/ansible/resources/erd-monitoring/openshift-monitoring-grafanadatasource.yml
@@ -1,0 +1,19 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: prometheus-openshift-monitoring
+spec:
+  datasources:
+    - access: proxy
+      editable: true
+      jsonData:
+        httpHeaderName1: Authorization
+        timeInterval: 5s
+        tlsSkipVerify: true
+      name: OpenShift Monitoring
+      secureJsonData:
+        httpHeaderValue1: >-
+          Bearer {{ token }}
+      type: prometheus
+      url: 'https://prometheus-k8s.openshift-monitoring.svc:9091'
+  name: openshift-monitoring.yaml

--- a/ansible/resources/monitoring/grafana-cluster-monitoring-view-crb.yml
+++ b/ansible/resources/monitoring/grafana-cluster-monitoring-view-crb.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grafana-cluster-monitoring-view{{ namespace_postfix }}
+subjects:
+  - kind: ServiceAccount
+    name: grafana-serviceaccount
+    namespace: {{ namespace_monitoring }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/ansible/roles/erd_monitoring/defaults/main.yml
+++ b/ansible/roles/erd_monitoring/defaults/main.yml
@@ -10,4 +10,5 @@ monitoring_dw_postgresql_datasource_template: dw-postgresql-grafanadatasource.ym
 
 openshift_monitoring_datasource_template: openshift-monitoring-grafanadatasource.yml
 
+incident_priority_prometheus_rules_template: incident-priority-service-prometheus-rules.yml
 incident_priority_service_dashboard_template: incident-priority-service-dashboard.yml

--- a/ansible/roles/erd_monitoring/defaults/main.yml
+++ b/ansible/roles/erd_monitoring/defaults/main.yml
@@ -7,3 +7,5 @@ monitoring_grafana_dashboard_template: emergency-response-grafanadashboard.yml
 
 monitoring_mission_commander_template: mission-commander-kpis-grafanadashboard.yml
 monitoring_dw_postgresql_datasource_template: dw-postgresql-grafanadatasource.yml
+
+openshift_monitoring_datasource_template: openshift-monitoring-grafanadatasource.yml

--- a/ansible/roles/erd_monitoring/defaults/main.yml
+++ b/ansible/roles/erd_monitoring/defaults/main.yml
@@ -9,3 +9,5 @@ monitoring_mission_commander_template: mission-commander-kpis-grafanadashboard.y
 monitoring_dw_postgresql_datasource_template: dw-postgresql-grafanadatasource.yml
 
 openshift_monitoring_datasource_template: openshift-monitoring-grafanadatasource.yml
+
+incident_priority_service_dashboard_template: incident-priority-service-dashboard.yml

--- a/ansible/roles/erd_monitoring/tasks/main.yml
+++ b/ansible/roles/erd_monitoring/tasks/main.yml
@@ -131,6 +131,16 @@
     files:
       - "{{ work_dir }}/{{ openshift_monitoring_datasource_template }}"
 
+- name: "create incident priority service prometheus rules"
+  oc_obj:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: incident-priority-service-prometheus-rules
+    namespace: "{{ namespace_monitoring }}"
+    kind: PrometheusRule
+    files:
+      - "{{ resources_dir }}/{{ incident_priority_prometheus_rules_template }}"
+
 - name: "copy incident priority service grafana dashboard template"
   template:
     src: "{{ resources_dir }}/{{ incident_priority_service_dashboard_template }}"

--- a/ansible/roles/erd_monitoring/tasks/main.yml
+++ b/ansible/roles/erd_monitoring/tasks/main.yml
@@ -108,3 +108,25 @@
     resource_kind: cluster-role
     resource_name: get-namespaces
     user: "{{ project_admin }}"
+
+- name: "obtain token for grafana serviceaccount"
+  shell: |
+    {{ openshift_cli }} sa get-token grafana-serviceaccount -n {{ namespace_monitoring }}
+  register: grafana_sa_token
+
+- name: "copy openshift monitoring grafana datasource template {{ openshift_monitoring_datasource_template }}"
+  template:
+    src: "{{ resources_dir }}/{{ openshift_monitoring_datasource_template }}"
+    dest: "{{ work_dir }}/{{ openshift_monitoring_datasource_template }}"
+  vars:
+    token: "{{ grafana_sa_token.stdout }}"
+
+- name: "create openshift monitoring grafana datasource"
+  oc_obj:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: prometheus-openshift-monitoring
+    namespace: "{{ namespace_monitoring }}"
+    kind: GrafanaDataSource
+    files:
+      - "{{ work_dir }}/{{ openshift_monitoring_datasource_template }}"

--- a/ansible/roles/erd_monitoring/tasks/main.yml
+++ b/ansible/roles/erd_monitoring/tasks/main.yml
@@ -130,3 +130,22 @@
     kind: GrafanaDataSource
     files:
       - "{{ work_dir }}/{{ openshift_monitoring_datasource_template }}"
+
+- name: "copy incident priority service grafana dashboard template"
+  template:
+    src: "{{ resources_dir }}/{{ incident_priority_service_dashboard_template }}"
+    dest: "{{ work_dir }}/{{ incident_priority_service_dashboard_template }}"
+  vars:
+    pod: !unsafe "{{pod}}"
+    action: !unsafe "{{action}}"
+    cause: !unsafe "{{cause}}"
+
+- name: "create incident priority service grafana dashboard"
+  oc_obj:
+    state: present
+    oc_binary: "{{ openshift_cli }}"
+    name: incident-priority-service-dashboard
+    namespace: "{{ namespace_monitoring }}"
+    kind: GrafanaDashboard
+    files:
+      - "{{ work_dir }}/{{ incident_priority_service_dashboard_template }}"

--- a/ansible/roles/erd_monitoring/tasks/uninstall.yml
+++ b/ansible/roles/erd_monitoring/tasks/uninstall.yml
@@ -62,3 +62,11 @@
     name: prometheus-openshift-monitoring
     namespace: "{{ namespace_monitoring }}"
     kind: GrafanaDataSource
+
+- name: "delete incident priority service grafana dashboard"
+  oc_obj:
+    state: absent
+    oc_binary: "{{ openshift_cli }}"
+    name: incident-priority-service-dashboard
+    namespace: "{{ namespace_monitoring }}"
+    kind: GrafanaDashboard

--- a/ansible/roles/erd_monitoring/tasks/uninstall.yml
+++ b/ansible/roles/erd_monitoring/tasks/uninstall.yml
@@ -54,3 +54,11 @@
     oc_binary: "{{ openshift_cli }}"
     name: "{{ project_admin }}-get-namespaces"
     kind: clusterrolebinding
+
+- name: "delete openshift monitoring grafana datasource"
+  oc_obj:
+    state: absent
+    oc_binary: "{{ openshift_cli }}"
+    name: prometheus-openshift-monitoring
+    namespace: "{{ namespace_monitoring }}"
+    kind: GrafanaDataSource

--- a/ansible/roles/erd_monitoring/tasks/uninstall.yml
+++ b/ansible/roles/erd_monitoring/tasks/uninstall.yml
@@ -70,3 +70,11 @@
     name: incident-priority-service-dashboard
     namespace: "{{ namespace_monitoring }}"
     kind: GrafanaDashboard
+
+- name: "delete incident priority service prometheus rules"
+  oc_obj:
+    state: absent
+    oc_binary: "{{ openshift_cli }}"
+    name: incident-priority-service-prometheus-rules
+    namespace: "{{ namespace_monitoring }}"
+    kind: PrometheusRule

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -34,3 +34,5 @@ application_monitoring_operator_role_binding_template: application_monitoring_op
 application_monitoring_operator_template: application_monitoring_operator.yml
 
 clusterrole_get_namespaces_template: get-namespaces-clusterrole.yml
+
+grafana_cluster_monitoring_view_crb_template: grafana-cluster-monitoring-view-crb.yml

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -301,3 +301,17 @@
     kind: clusterrole
     files:
       - "{{ resources_dir }}/{{ clusterrole_get_namespaces_template }}"
+
+- name: "copy grafana cluster monitoring clusterrole binding template"
+  template:
+    src: "{{ resources_dir }}/{{ grafana_cluster_monitoring_view_crb_template }}"
+    dest: "{{ work_dir }}/{{ grafana_cluster_monitoring_view_crb_template }}"
+
+- name: "grafana cluster monitoring clusterrole binding"
+  oc_obj:
+    oc_binary: "{{ openshift_cli }}"
+    state: present
+    kind: clusterrolebinding
+    name: "grafana-cluster-monitoring-view{{ namespace_postfix }}"
+    files:
+      - "{{ work_dir }}/{{ grafana_cluster_monitoring_view_crb_template }}"

--- a/ansible/roles/monitoring/tasks/uninstall.yml
+++ b/ansible/roles/monitoring/tasks/uninstall.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: "delete grafana cluster monitoring clusterrole binding"
+  oc_obj:
+    oc_binary: "{{ openshift_cli }}"
+    state: absent
+    kind: clusterrolebinding
+    name: "grafana-cluster-monitoring-view{{ namespace_postfix }}"
+
 - name: "delete application monitoring cr"
   oc_obj:
     oc_binary: "{{ openshift_cli }}"


### PR DESCRIPTION
Kafka Lag exporter allows to measure the lag in kafka message consumption per consumer group.

https://github.com/lightbend/kafka-lag-exporter