### PR TITLE
AMQ Streams 1.4.0: metrics port is now called 'prometheus'

### DIFF
--- a/ansible/resources/erd-monitoring/emergency-response-kafka-servicemonitor.yml
+++ b/ansible/resources/erd-monitoring/emergency-response-kafka-servicemonitor.yml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
     - interval: 5s
-      port: metrics
+      port: prometheus
   selector:
     matchLabels:
       strimzi.io/kind: Kafka


### PR DESCRIPTION
Closes #81 